### PR TITLE
includes default tag setting for initial run

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -15,6 +15,16 @@ jobs:
       with:
         tags: true
 
+    - name: Check for Tags
+      id: check_tags
+      run: |
+        if [ $(git tag | wc -l) -eq 0 ]; then
+          echo "No tags found, setting initial tag to v1.0.0"
+          git tag v1.0.0
+          git push --tags
+          echo "tag_setup=true" >> ${GITHUB_OUTPUT}
+        fi
+
     - name: Generate Changelog
       id: changelog
       uses: mikepenz/release-changelog-builder-action@v4.2.0


### PR DESCRIPTION
# Overview

Includes a block to set the initial version tag of `v1.0.0` if there are no other tags. This will allow the steps to run "out of the box" to so speak without any initial tagging or manual work on the part of the dev.