### PR TITLE
Amend initialization script to include initial tagging

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -21,6 +21,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
         if [ $(git tag | wc -l) -eq 0 ]; then
           echo "No tags found, setting initial tag to v1.0.0"
           git tag v1.0.0

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -15,19 +15,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        tags: true
-
-    - name: Check for Tags
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-        if [ $(git tag | wc -l) -eq 0 ]; then
-          echo "No tags found, setting initial tag to v1.0.0"
-          git tag v1.0.0
-          git push --tags
-          echo "tag_setup=true" >> ${GITHUB_OUTPUT}
-        fi
+        fetch-depth: 0
 
     - name: Generate Changelog
       id: changelog

--- a/INITIALIZE_REPOSITORY.sh
+++ b/INITIALIZE_REPOSITORY.sh
@@ -35,11 +35,8 @@ NAMESPACE="$(echo "$REPO_URL" | awk -F'/' '{print $(NF-1)}' | awk -F':' '{print 
 
 echo "Generated namespace: $NAMESPACE"
 echo ""
-
-# Replace REPONAME in files
-find . -type f -not -path "./.git/*" -exec sed -i '' "s/NAMESPACE/$NAMESPACE/g" {} +
-
 echo "Renaming directories and files"
+echo ""
 
 # Optional: Rename files or directories if needed
 mv src/PROJECTNAME/PROJECTNAME.cs src/PROJECTNAME/"$PROJECT_NAME".cs
@@ -48,6 +45,7 @@ mv src/PROJECTNAME src/"$PROJECT_NAME"
 mv src/PROJECTNAME.Tests src/"$PROJECT_NAME".Tests
 
 echo "Initializing .NET solution and project files"
+echo ""
 
 # Create the main solution
 dotnet new sln -n "$PROJECT_NAME"
@@ -91,9 +89,28 @@ sed -i '' "/<\/Project>/i \\
   \\
 " "src/${PROJECT_NAME}.Tests/${PROJECT_NAME}.Tests.csproj"
 
+echo "Adding CI workflow"
+echo ""
+
+cat <<EOF > .github/workflows/dotnet-ci.yaml
+name: .NET Continuous Integration
+
+on:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run .NET CI Action
+        uses: jmsudar/dotnet-continuous-integration@main
+EOF
+
 echo "Cleaning up files and dependencies"
+echo ""
 
 echo "Replacing NAMESPACE with $NAMESPACE"
+echo ""
 
 # Replace NAMESPACE with your project name
 sed -i '' "s/NAMESPACE/$NAMESPACE/g" "src/${PROJECT_NAME}/${PROJECT_NAME}.cs"
@@ -109,6 +126,7 @@ rm "src/${PROJECT_NAME}.Tests/UnitTest1.cs"
 rm "src/${PROJECT_NAME}.Tests/Usings.cs"
 
 echo "Deleting initialization script"
+echo ""
 
 # Self-delete the script
 rm -- "$0"

--- a/INITIALIZE_REPOSITORY.sh
+++ b/INITIALIZE_REPOSITORY.sh
@@ -30,6 +30,10 @@ if [ -z "$REPO_URL" ]; then
   exit 1
 fi
 
+# Push the initial tag of v1.0.0 if the remote URL is valid
+git tag -a v1.0.0 -m "Initial commit"
+git push origin v1.0.0
+
 # Format the namespace: replace dashes with dots and convert to lowercase if necessary
 NAMESPACE="$(echo "$REPO_URL" | awk -F'/' '{print $(NF-1)}' | awk -F':' '{print $NF}').$(echo "$REPO_URL" | awk -F'/' '{print $NF}' | sed 's/\.git$//')"
 


### PR DESCRIPTION
# Overview

Added the following lines to `INITIALIZE_REPOSITORY.sh`

```shell
# Push the initial tag of v1.0.0 if the remote URL is valid
git tag -a v1.0.0 -m "Initial commit"
git push origin v1.0.0
```

This replaces a line in `create-release.yaml` which did a check for existing tags. This will technically tag the remote prior to a release, but is overall less costly in ongoing CD checks, therefore preferable.